### PR TITLE
:construction_worker: Add pre-commit action to check PRs and master

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,18 @@
+---
+# SPDX-FileCopyrightText: 2022 Stefan Haun <tux@netz39.de>
+# SPDX-License-Identifier: MIT
+
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v3
+      - uses: pre-commit/action@v3.0.0


### PR DESCRIPTION
Based on https://github.com/pre-commit/action to ensure that the pre-commit checks are executed for every PR.

This fixes #2 

There is a CI service to execute the pre-commit hooks, however, they want a lot of rights to the repository. It seems to be more stable and less invasive to privacy to use an action instead.