### PR TITLE
:bug: Ensure configuration directory exists

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,6 +18,12 @@
   ansible.builtin.getent:
     database: group
 
+- name: Make sure the configuration directory exists
+  ansible.builtin.file:
+    path: "{{ tdid_conf_dir }}"
+    state: directory
+    mode: '0755'
+
 - name: Copy telegraf docker_input_agent conf
   ansible.builtin.template:
     src: templates/docker_input_agent.conf.j2


### PR DESCRIPTION
Create the configuration directory in tdid_conf_dir if it does not exist, so that the following copy does not fail.

Fixes: #15