### PR TITLE
:construction_worker: pre-commit: Bump dependencies (autoupdate)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,19 +6,19 @@ repos:
     hooks:
       - id: check-hooks-apply
   - repo: https://github.com/fsfe/reuse-tool
-    rev: v1.1.0
+    rev: v3.0.1
     hooks:
       - id: reuse
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: check-yaml
   - repo: https://github.com/adrienverge/yamllint
-    rev: v1.28.0
+    rev: v1.33.0
     hooks:
       - id: yamllint
   - repo: https://github.com/ansible-community/ansible-lint
-    rev: v6.9.1
+    rev: v6.22.2
     hooks:
       - id: ansible-lint


### PR DESCRIPTION
Previously this failed like this:

    % pre-commit run
    Check hooks apply to the repository..................(no files to check)Skipped
    reuse................................................(no files to check)Skipped
    trim trailing whitespace.............................(no files to check)Skipped
    check yaml...........................................(no files to check)Skipped
    yamllint.............................................(no files to check)Skipped
    Ansible-lint.............................................................Failed
    - hook id: ansible-lint
    - exit code: 1

    Traceback (most recent call last):
      File "<frozen runpy>", line 198, in _run_module_as_main
      File "<frozen runpy>", line 88, in _run_code
      File "/home/alex/.cache/pre-commit/repol_14pvzv/py_env-python3/lib/python3.11/site-packages/ansiblelint/__main__.py", line 453, in <module>
        _run_cli_entrypoint()
      File "/home/alex/.cache/pre-commit/repol_14pvzv/py_env-python3/lib/python3.11/site-packages/ansiblelint/__main__.py", line 347, in _run_cli_entrypoint
        sys.exit(main(sys.argv))
                 ^^^^^^^^^^^^^^
      File "/home/alex/.cache/pre-commit/repol_14pvzv/py_env-python3/lib/python3.11/site-packages/ansiblelint/__main__.py", line 197, in main
        initialize_options(argv[1:])
      File "/home/alex/.cache/pre-commit/repol_14pvzv/py_env-python3/lib/python3.11/site-packages/ansiblelint/__main__.py", line 110, in initialize_options
        options.cache_dir = get_cache_dir(options.project_dir)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/alex/.cache/pre-commit/repol_14pvzv/py_env-python3/lib/python3.11/site-packages/ansible_compat/prerun.py", line 13, in get_cache_dir
        basename = project_dir.resolve().name.encode(encoding="utf-8")
                   ^^^^^^^^^^^^^^^^^^^
    AttributeError: 'str' object has no attribute 'resolve'