### PR TITLE
:children_crossing: Skip tasks on certain architectures

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,48 +3,53 @@
 ---
 # tasks file for telegraf-docker-in-docker
 
-- name: Ensure system user is present on the host and in group docker
-  ansible.builtin.user:
-    name: "{{ tdid_user }}"
-    system: true
-    append: true
-    groups: docker
+- name: Run all tasks for role telegraf-docker-in-docker
+  # TODO Add armv8 once the correct string is known
+  when: (ansible_architecture == "x86_64") or
+        (ansible_architecture == "armv7l")
+  block:
+    - name: Ensure system user is present on the host and in group docker
+      ansible.builtin.user:
+        name: "{{ tdid_user }}"
+        system: true
+        append: true
+        groups: docker
 
-- name: Get user info
-  ansible.builtin.getent:
-    database: passwd
+    - name: Get user info
+      ansible.builtin.getent:
+        database: passwd
 
-- name: Get group info
-  ansible.builtin.getent:
-    database: group
+    - name: Get group info
+      ansible.builtin.getent:
+        database: group
 
-- name: Make sure the configuration directory exists
-  ansible.builtin.file:
-    path: "{{ tdid_conf_dir }}"
-    state: directory
-    mode: '0755'
+    - name: Make sure the configuration directory exists
+      ansible.builtin.file:
+        path: "{{ tdid_conf_dir }}"
+        state: directory
+        mode: '0755'
 
-- name: Copy telegraf docker_input_agent conf
-  ansible.builtin.template:
-    src: templates/docker_input_agent.conf.j2
-    dest: "{{ tdid_conf_dir }}/docker_input_agent.conf"
-    mode: '0644'
-  notify:
-    - Restart telegraf docker_input_agent
+    - name: Copy telegraf docker_input_agent conf
+      ansible.builtin.template:
+        src: templates/docker_input_agent.conf.j2
+        dest: "{{ tdid_conf_dir }}/docker_input_agent.conf"
+        mode: '0644'
+      notify:
+        - Restart telegraf docker_input_agent
 
-- name: Setup docker container for telegraf (Docker)
-  community.docker.docker_container:
-    name: telegraf_docker_input_agent
-    image: "{{ tdid_docker_image }}"
-    pull: true
-    state: started
-    detach: true
-    restart_policy: unless-stopped
-    env:
-      TZ: "{{ tdid_timezone }}"
-      INFLUX_TOKEN: "{{ tdid_influx_token }}"
-    volumes:
-      - "/var/run/docker.sock:/run/docker.sock"
-      - "{{ tdid_conf_dir }}/docker_input_agent.conf:/etc/telegraf/telegraf.conf:ro"
-    # user: "telegraf:docker"
-    user: "{{ ansible_facts.getent_passwd[tdid_user][1] }}:{{ ansible_facts.getent_group['docker'][1] }}"
+    - name: Setup docker container for telegraf (Docker)
+      community.docker.docker_container:
+        name: telegraf_docker_input_agent
+        image: "{{ tdid_docker_image }}"
+        pull: true
+        state: started
+        detach: true
+        restart_policy: unless-stopped
+        env:
+          TZ: "{{ tdid_timezone }}"
+          INFLUX_TOKEN: "{{ tdid_influx_token }}"
+        volumes:
+          - "/var/run/docker.sock:/run/docker.sock"
+          - "{{ tdid_conf_dir }}/docker_input_agent.conf:/etc/telegraf/telegraf.conf:ro"
+        # user: "telegraf:docker"
+        user: "{{ ansible_facts.getent_passwd[tdid_user][1] }}:{{ ansible_facts.getent_group['docker'][1] }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,12 +3,12 @@
 ---
 # main tasks file for telegraf-docker-in-docker
 
-- name: Run all tasks for role telegraf-docker-in-docker
+- name: Check if the role can be applied to the target host
   when: tdid_arch_is_supported
   ansible.builtin.include_tasks:
     file: tdid.yml
 
-- name: Inform user why tasks for role telegraf-docker-in-docker were skipped
+- name: Inform user why tasks for role were skipped
   ansible.builtin.debug:
     msg: "Skipped because there is no docker image for {{ ansible_architecture }}!"
   when: not tdid_arch_is_supported

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,5 +10,5 @@
 
 - name: Inform user why tasks for role telegraf-docker-in-docker were skipped
   ansible.builtin.debug:
-    msg: "Skipped because for {{ ansible_architecture }} there is no docker image!"
+    msg: "Skipped because there is no docker image for {{ ansible_architecture }}!"
   when: not tdid_arch_is_supported

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,56 +1,12 @@
 # SPDX-FileCopyrightText: 2022 Alexander Dahl <alex@netz39.de>
 # SPDX-License-Identifier: MIT
 ---
-# tasks file for telegraf-docker-in-docker
+# main tasks file for telegraf-docker-in-docker
 
 - name: Run all tasks for role telegraf-docker-in-docker
   when: tdid_arch_is_supported
-  block:
-    - name: Ensure system user is present on the host and in group docker
-      ansible.builtin.user:
-        name: "{{ tdid_user }}"
-        system: true
-        append: true
-        groups: docker
-
-    - name: Get user info
-      ansible.builtin.getent:
-        database: passwd
-
-    - name: Get group info
-      ansible.builtin.getent:
-        database: group
-
-    - name: Make sure the configuration directory exists
-      ansible.builtin.file:
-        path: "{{ tdid_conf_dir }}"
-        state: directory
-        mode: '0755'
-
-    - name: Copy telegraf docker_input_agent conf
-      ansible.builtin.template:
-        src: templates/docker_input_agent.conf.j2
-        dest: "{{ tdid_conf_dir }}/docker_input_agent.conf"
-        mode: '0644'
-      notify:
-        - Restart telegraf docker_input_agent
-
-    - name: Setup docker container for telegraf (Docker)
-      community.docker.docker_container:
-        name: telegraf_docker_input_agent
-        image: "{{ tdid_docker_image }}"
-        pull: true
-        state: started
-        detach: true
-        restart_policy: unless-stopped
-        env:
-          TZ: "{{ tdid_timezone }}"
-          INFLUX_TOKEN: "{{ tdid_influx_token }}"
-        volumes:
-          - "/var/run/docker.sock:/run/docker.sock"
-          - "{{ tdid_conf_dir }}/docker_input_agent.conf:/etc/telegraf/telegraf.conf:ro"
-        # user: "telegraf:docker"
-        user: "{{ ansible_facts.getent_passwd[tdid_user][1] }}:{{ ansible_facts.getent_group['docker'][1] }}"
+  ansible.builtin.include_tasks:
+    file: tdid.yml
 
 - name: Inform user why tasks for role telegraf-docker-in-docker were skipped
   ansible.builtin.debug:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,9 +4,7 @@
 # tasks file for telegraf-docker-in-docker
 
 - name: Run all tasks for role telegraf-docker-in-docker
-  # TODO Add armv8 once the correct string is known
-  when: (ansible_architecture == "x86_64") or
-        (ansible_architecture == "armv7l")
+  when: tdid_arch_is_supported
   block:
     - name: Ensure system user is present on the host and in group docker
       ansible.builtin.user:
@@ -53,3 +51,8 @@
           - "{{ tdid_conf_dir }}/docker_input_agent.conf:/etc/telegraf/telegraf.conf:ro"
         # user: "telegraf:docker"
         user: "{{ ansible_facts.getent_passwd[tdid_user][1] }}:{{ ansible_facts.getent_group['docker'][1] }}"
+
+- name: Inform user why tasks for role telegraf-docker-in-docker were skipped
+  ansible.builtin.debug:
+    msg: "Skipped because for {{ ansible_architecture }} there is no docker image!"
+  when: not tdid_arch_is_supported

--- a/tasks/tdid.yml
+++ b/tasks/tdid.yml
@@ -1,0 +1,50 @@
+# SPDX-FileCopyrightText: 2025 Alexander Dahl <alex@netz39.de>
+# SPDX-License-Identifier: MIT
+---
+# implementation tasks file for telegraf-docker-in-docker
+
+- name: Ensure system user is present on the host and in group docker
+  ansible.builtin.user:
+    name: "{{ tdid_user }}"
+    system: true
+    append: true
+    groups: docker
+
+- name: Get user info
+  ansible.builtin.getent:
+    database: passwd
+
+- name: Get group info
+  ansible.builtin.getent:
+    database: group
+
+- name: Make sure the configuration directory exists
+  ansible.builtin.file:
+    path: "{{ tdid_conf_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Copy telegraf docker_input_agent conf
+  ansible.builtin.template:
+    src: templates/docker_input_agent.conf.j2
+    dest: "{{ tdid_conf_dir }}/docker_input_agent.conf"
+    mode: '0644'
+  notify:
+    - Restart telegraf docker_input_agent
+
+- name: Setup docker container for telegraf (Docker)
+  community.docker.docker_container:
+    name: telegraf_docker_input_agent
+    image: "{{ tdid_docker_image }}"
+    pull: true
+    state: started
+    detach: true
+    restart_policy: unless-stopped
+    env:
+      TZ: "{{ tdid_timezone }}"
+      INFLUX_TOKEN: "{{ tdid_influx_token }}"
+    volumes:
+      - "/var/run/docker.sock:/run/docker.sock"
+      - "{{ tdid_conf_dir }}/docker_input_agent.conf:/etc/telegraf/telegraf.conf:ro"
+    # user: "telegraf:docker"
+    user: "{{ ansible_facts.getent_passwd[tdid_user][1] }}:{{ ansible_facts.getent_group['docker'][1] }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2025 Alexander Dahl <alex@netz39.de>
+# SPDX-License-Identifier: MIT
+---
+# vars file for telegraf-docker-in-docker
+
+# TODO Add armv8 once the correct string is known
+tdid_arch_is_supported: >-
+  {{
+    (ansible_architecture == 'x86_64') or
+    (ansible_architecture == 'armv7l')
+  }}


### PR DESCRIPTION
The docker images for Telegraf are only provided for certain architectures.  Move all related tasks in a conditional block.

Link: https://hub.docker.com/_/telegraf
Fixes: #17