### PR TITLE
:technologist: mailmap: Update with new mail address

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,5 +1,6 @@
 # SPDX-FileCopyrightText: 2024 Alexander Dahl <alex@netz39.de>
 # SPDX-License-Identifier: CC0-1.0
 
-Alexander Dahl <alex@netz39.de> <post@lespocky.de>
-Stefan Haun <tux@netz39.de> <mail@tuxathome.de>
+<alex@netz39.de> <post@lespocky.de>
+<alex@netz39.de> <ada@thorsis.com>
+<tux@netz39.de> <mail@tuxathome.de>


### PR DESCRIPTION
Someone™ committed with another new mail address by accident. Removed the names in the front, because those were used correctly, and only mail addresses need to be mapped for now.