### PR TITLE
:children_crossing: Improve docker image availability check

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,6 +3,13 @@
 ---
 # main tasks file for telegraf-docker-in-docker
 
+- name: Debug output of variables
+  ansible.builtin.debug:
+    msg:
+      - "tdid_arch_has_alpine_image: {{ tdid_arch_has_alpine_image }}"
+      - "tdid_arch_is_supported: {{ tdid_arch_is_supported }}"
+      - "tdid_docker_image_is_supported: {{ tdid_docker_image_is_supported }}"
+
 - name: Check if the role can be applied to the target host
   when: tdid_docker_image_is_supported
   ansible.builtin.include_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,11 +4,11 @@
 # main tasks file for telegraf-docker-in-docker
 
 - name: Check if the role can be applied to the target host
-  when: tdid_arch_is_supported
+  when: tdid_docker_image_is_supported
   ansible.builtin.include_tasks:
     file: tdid.yml
 
 - name: Inform user why tasks for role were skipped
   ansible.builtin.debug:
-    msg: "Skipped because there is no docker image for {{ ansible_architecture }}!"
-  when: not tdid_arch_is_supported
+    msg: "Skipped because there is no docker image '{{ tdid_docker_image }}' for {{ ansible_architecture }}!"
+  when: not tdid_docker_image_is_supported

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,9 +3,23 @@
 ---
 # vars file for telegraf-docker-in-docker
 
+# Link: https://github.com/influxdata/influxdata-docker/blob/master/telegraf/1.35/alpine/Dockerfile
+# TODO Add armv8 once the correct string is known
+tdid_arch_has_alpine_image: >-
+  {{
+    (ansible_architecture == 'x86_64')
+  }}
+
+# Link: https://github.com/influxdata/influxdata-docker/blob/master/telegraf/1.35/Dockerfile
 # TODO Add armv8 once the correct string is known
 tdid_arch_is_supported: >-
   {{
     (ansible_architecture == 'x86_64') or
     (ansible_architecture == 'armv7l')
+  }}
+
+tdid_docker_image_is_supported: >-
+  {{
+    tdid_arch_is_supported and
+    not (tdid_docker_image is search("alpine") and not tdid_arch_has_alpine_image)
   }}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -18,6 +18,8 @@ tdid_arch_is_supported: >-
     (ansible_architecture == 'armv7l')
   }}
 
+# If user configured image containing "alpine", but there is no alpine
+# for that arch, then that image is not supported.
 tdid_docker_image_is_supported: >-
   {{
     tdid_arch_is_supported and


### PR DESCRIPTION
While investigating #17 we found out there are Telegraf Docker images for a number of different architectures.  The alternative Docker image based on Alpine Linux is only available for some of them.  We already had a check testing for image availability, but it was ignoring that case.  Improve it.

Tested against x86_64, i386 and armv7l architectures with both Docker image variants.  All combinations not supported are skipped now.