### PR TITLE
:rotating_light: Remove yaml truthy exceptions

### DIFF
--- a/.yamllint
+++ b/.yamllint
@@ -5,9 +5,3 @@ extends: default
 
 rules:
   line-length: disable
-  truthy:
-    allowed-values:
-      - 'true'
-      - 'false'
-      - 'yes'
-      - 'no'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -6,4 +6,4 @@
   community.docker.docker_container:
     name: telegraf_docker_input_agent
     state: started
-    restart: yes
+    restart: true


### PR DESCRIPTION
In an environment not considering .yamllint (like galaxy role import) there was only one easy to fix warning:

    ===== LOADING ROLE =====
    Importing with galaxy-importer 0.4.31
    Determined role name to be telegraf_docker_in_docker
    Linting role telegraf_docker_in_docker via ansible-lint 24.12.2...
    ansible-role-telegraf-docker-in-docker/handlers/main.yml:5:3: syntax-check[unknown-module]: couldn't resolve module/action 'community.docker.docker_container'. This often indicates a misspelling, missing collection, or incorrect module path.
    ansible-role-telegraf-docker-in-docker/handlers/main.yml:9: yaml[truthy][/]: Truthy value should be one of [false, true]
    ...ansible-lint run complete
    Legacy role loading complete

Simplify by switching to standard yaml keywords here.

Link: https://galaxy.ansible.com/ui/standalone/roles/lespocky/telegraf_docker_in_docker/import_log/