### PR TITLE
:wrench: renovate: Use gitmoji for commit messages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "commitMessagePrefix": ":arrow_up:",
   "configMigration": true,
   "customManagers": [
     {


### PR DESCRIPTION
Currently this project uses gitmoji.  Although that might change in the future it is the way to go at the moment, so let Renovate Bot play nice.

Link: https://docs.renovatebot.com/configuration-options/#commitmessageprefix
Link: https://gitmoji.dev/